### PR TITLE
Add minimal service worker for offline support

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,64 @@
+const CACHE_NAME = 'tcg-collector-cache-v1';
+const BASE_PATH = self.location.pathname.replace(/[^/]+$/, '');
+
+const PRECACHE_URLS = [
+  './',
+  'index.html',
+  'styles.css',
+  'pokemonData.js',
+  'index2.html',
+].map((path) => new URL(path, self.location.origin + BASE_PATH).toString());
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(PRECACHE_URLS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(
+          cacheNames
+            .filter((cacheName) => cacheName !== CACHE_NAME)
+            .map((cacheName) => caches.delete(cacheName))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request)
+        .then((response) => {
+          if (!response || response.status !== 200 || response.type !== 'basic') {
+            return response;
+          }
+
+          const responseToCache = response.clone();
+
+          caches.open(CACHE_NAME).then((cache) => {
+            cache.put(event.request, responseToCache);
+          });
+
+          return response;
+        })
+        .catch(() => caches.match(PRECACHE_URLS[1]));
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add a service worker that precaches the main app shell assets
- ensure cache paths resolve correctly under the GitHub Pages base path
- provide basic runtime caching with network fallback and offline fallback to the cached shell

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b71f0a2c83228918ff4c35b0159e